### PR TITLE
remove hardcoded DNS configuration 

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,15 @@
 set -Eeuo pipefail
 trap "echo TRAPed signal" HUP INT QUIT TERM
 
+#configure nginx DNS settings to match host, why must we do that nginx?
+conf="resolver $(/usr/bin/awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf) ipv6=off; # Avoid ipv6 addresses for now"
+[ "$conf" = "resolver ;" ] && echo "no nameservers found" && exit 0
+confpath=/etc/nginx/resolvers.conf
+if [ ! -e $confpath ] || [ "$conf" != "$(cat $confpath)" ]
+then
+    echo "$conf" > $confpath
+fi
+
 # The list of SAN (Subject Alternative Names) for which we will create a TLS certificate.
 ALLDOMAINS=""
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -108,7 +108,8 @@ http {
         proxy_max_temp_file_size 0;
 
         # We need to resolve the real names of our proxied servers.
-        resolver 8.8.8.8 4.2.2.2 ipv6=off; # Avoid ipv6 addresses for now
+        #resolver 8.8.8.8 4.2.2.2 ipv6=off; # Avoid ipv6 addresses for now
+        include /etc/nginx/resolvers.conf;
 
         # forward proxy for non-CONNECT request
         location / {
@@ -140,7 +141,8 @@ http {
         ssl_certificate_key /certs/web.key;
 
         # We need to resolve the real names of our proxied servers.
-        resolver 8.8.8.8 4.2.2.2 ipv6=off; # Avoid ipv6 addresses for now
+        #resolver 8.8.8.8 4.2.2.2 ipv6=off; # Avoid ipv6 addresses for now
+        include /etc/nginx/resolvers.conf;
 
         # Docker needs this. Don't ask.
         chunked_transfer_encoding on;


### PR DESCRIPTION
This is to fix issue https://github.com/rpardini/docker-registry-proxy/issues/6#issuecomment-445972540
This will pick up DNS configuration from the container and bootstrap nginx with it.
No need for static DNS value, solves name resolution errors when behind a firewall.