### PR TITLE
Move apk add and del into same layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,11 @@ FROM rpardini/nginx-proxy-connect-stable-alpine:nginx-1.14.0-alpine-3.8
 
 # Add openssl, bash and ca-certificates, then clean apk cache -- yeah complain all you want.
 # Also added deps for mitmproxy.
-RUN apk add --update openssl bash ca-certificates su-exec git g++ libffi libffi-dev libstdc++ openssl openssl-dev python3 python3-dev
-RUN LDFLAGS=-L/lib pip3 install mitmproxy
-RUN apk del --purge git g++ libffi-dev openssl-dev python3-dev && rm -rf /var/cache/apk/* && rm -rf ~/.cache/pip
+RUN apk add --update openssl bash ca-certificates su-exec git g++ libffi libffi-dev libstdc++ openssl openssl-dev python3 python3-dev \
+ && LDFLAGS=-L/lib pip3 install mitmproxy \
+ && apk del --purge git g++ libffi-dev openssl-dev python3-dev \
+ && rm -rf /var/cache/apk/* \
+ && rm -rf ~/.cache/pip
 
 # Required for mitmproxy
 ENV LANG=en_US.UTF-8


### PR DESCRIPTION
Because the apk add and del commands were running in separate RUN statements, they were creating separate container image layers unnecessarily.

This PR moves them into the same command to reduce the final image size slightly.