### PR TITLE
Follow redirects and cache them properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+clean:
+	rm -rf docker_mirror_cache/*
+
+build:
+	docker build --tag docker-registry-proxy .
+
+start:
+	docker run --rm --name=docker-registry-proxy -it \
+		-p 0.0.0.0:3128:3128 \
+		-p 0.0.0.0:8081:8081 \
+		-e DEBUG=true \
+		-v $(dir $(abspath $(firstword $(MAKEFILE_LIST))))/docker_mirror_cache:/docker_mirror_cache \
+		-v $(dir $(abspath $(firstword $(MAKEFILE_LIST))))/docker_mirror_certs:/ca \
+		docker-registry-proxy
+
+stop:
+	docker stop docker-registry-proxy
+
+test: build start
+
+.INTERMEDIATE: clean stop

--- a/nginx.conf
+++ b/nginx.conf
@@ -198,8 +198,8 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
         proxy_cache_lock on;
         proxy_cache_lock_timeout 880s;
 
-        # Cache all 200, 301, 302, and 307 (emitted by private registries) for 60 days.
-        proxy_cache_valid 200 301 302 307 60d;
+        # Cache all 200, 206 for 60 days.
+        proxy_cache_valid 200 206 60d;
 
         # Some extra settings to maximize cache hits and efficiency
         proxy_force_ranges on;
@@ -225,47 +225,28 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
             return 405 "docker-registry-proxy: docker is trying to use v1 API. Either the image does not exist upstream, or you need to configure docker-registry-proxy to authenticate against $host";
         }
 
-
         # for the /v2/..../blobs/.... URIs, do cache, and treat redirects.
         location ~ ^/v2/(.*)/blobs/ {
             proxy_pass https://$targetHost;
             proxy_cache cache;
-            add_header X-Docker-Caching-Proxy-Debug-Cache "yes:blobs";
-
-            # Handling of redirects.
-            # Many registries (eg, quay.io, or k8s.gcr.io) emit a Location redirect
-            # pointing to something like cloudfront, or google storage.
-            # We hack into the response, extracting the host and URI parts, injecting them into a URL that points back to us
-            # That gives us a chance to intercept and cache those, which are the actual multi-megabyte blobs we originally wanted to cache.
-            # We to it twice, one for http and another for https.
-            proxy_redirect ~^https://([^:/]+)(/.+)$ https://docker.caching.proxy.internal/forcecachesecure/$1/originalwas$2;
-            proxy_redirect ~^http://([^:/]+)(/.+)$ http://docker.caching.proxy.internal/forcecacheinsecure/$1/originalwas$2;
+            proxy_cache_key   $uri;
+            proxy_intercept_errors on;
+            error_page 301 302 307 = @handle_redirects;
         }
 
+        location @handle_redirects {
+            #store the current state of the world so we can reuse it in a minute
+            # We need to capture these values now, because as soon as we invoke
+            # the proxy_* directives, these will disappear
+            set $original_uri $uri;
+            set $orig_loc $upstream_http_location;
 
-        # handling for the redirect case explained above, with https.
-        # The $realHost and $realPath variables come from a map defined at the top of this file.
-        location /forcecachesecure {
-            proxy_pass https://$realHost$realPath;
+            # nginx goes to fetch the value from the upstream Location header
+            proxy_pass $orig_loc;
             proxy_cache cache;
-
-            # Change the cache key, so that we can cache signed S3 requests and such. Only host and path are considered.
-            proxy_cache_key $proxy_host$uri;
-
-            add_header X-Docker-Caching-Proxy-Debug-Cache "yes:forcecachesecure";
-
-        }
-
-        # handling for the redirect case explained above, with http.
-        # The $realHost and $realPath variables come from a map defined at the top of this file.
-        location /forcecacheinsecure {
-            proxy_pass http://$realHost$realPath;
-            proxy_cache cache;
-
-            # Change the cache key, so that we can cache signed S3 requests and such. Only host and path are considered.
-            proxy_cache_key $proxy_host$uri;
-
-            add_header X-Docker-Caching-Proxy-Debug-Cache "yes:forcecacheinsecure";
+            # But we store the result with the cache key of the original request URI
+            # so that future clients don't need to follow the redirect too
+            proxy_cache_key $original_uri;
         }
 
         # by default, dont cache anything.
@@ -274,6 +255,5 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
             proxy_cache off;
             add_header X-Docker-Caching-Proxy-Debug-Cache "no:default";
         }
-
     }
 }


### PR DESCRIPTION
Fixes https://github.com/rpardini/docker-registry-proxy/issues/26

## How to test?

* Checkout this branch
* Run `make test`
* In your browser, go to http://127.0.0.1:8081/ to open the mitmproxy
* In a new terminal, run: `env HTTP_PROXY=http://127.0.0.1:3128/ HTTPS_PROXY=http://127.0.0.1:3128/ http_proxy=127.0.0.1:3128 curl https://quay.io/v2/calico/cni/blobs/sha256:2c72d89b5a7fa12faeb77e0fccde73303b21ba3ca65ed614dfb1a8725c5a339f -k -vvv`
* You'll see that the first request takes a bit longer, if you do more requests, they go super fast (cached).
* When you check the mitmproxy, and inspect the responses from every request, you see that they all have the same `X-Amz-Cf-Id`. That's good, because it's cached.
* You see that the `docker_mirror_cache` directory is filled with 1 cache entry and not 2 (in current master, where it would cache the first response, and then let the client follow the redirect, and then cache the second blob).
* If you run `make clean` to clear the cache, and do a new request, you see `X-Amz-Cf-Id` changing.
* Quay uses signed url's that are valid for 10 minutes. So let's wait for at least 10 minutes and try to request it again... it should not fail and be served from cache.

## Credits

I found [this gist](https://gist.github.com/sirsquidness/710bc76d7bbc734c7a3ff69c6b8ff591) and it inspired me to apply. I think the current method in master is a bit too complicated but maybe that's for a good reason that I'm not aware of.