### PR TITLE
Fix extra space in base64 encoded auth string 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM rpardini/nginx-proxy-connect-stable-alpine:nginx-1.14.0-alpine-3.8
 
 # Add openssl, bash and ca-certificates, then clean apk cache -- yeah complain all you want.
 # Also added deps for mitmproxy.
-RUN apk add --update openssl bash ca-certificates su-exec git g++ libffi libffi-dev libstdc++ openssl openssl-dev python3 python3-dev
+RUN apk add --update openssl bash ca-certificates su-exec coreutils git g++ libffi libffi-dev libstdc++ openssl openssl-dev python3 python3-dev
 RUN LDFLAGS=-L/lib pip3 install mitmproxy
 RUN apk del --purge git g++ libffi-dev openssl-dev python3-dev && rm -rf /var/cache/apk/* && rm -rf ~/.cache/pip
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ docker run --rm --name docker_registry_proxy -it \
        -v $(pwd)/docker_mirror_certs:/ca \
        -e REGISTRIES="k8s.gcr.io gcr.io quay.io your.own.registry another.public.registry" \
        -e AUTH_REGISTRIES="auth.docker.io:dockerhub_username:dockerhub_password your.own.registry:username:password" \
-       rpardini/docker-registry-proxy:0.2.4
+       docker-registry-proxy:latest
 ```
 
 Let's say you did this on host `192.168.66.72`, you can then `curl http://192.168.66.72:3128/ca.crt` and get the proxy CA certificate.
@@ -112,6 +112,5 @@ Yeah. Docker Inc should do it. So should NPM, Inc. Wonder why they don't. 😼
 - Allow using multiple credentials for DockerHub; this is possible since the `/token` request includes the wanted repo as a query string parameter.
 - Test and make auth work with quay.io, unfortunately I don't have access to it (_hint, hint, quay_)
 - Make the cache size configurable, today it's fixed at 32gb.
-- Hide the mitmproxy building code under a Docker build ARG.
 - I hope that in the future this can also be used as a "Developer Office" proxy, where many developers on a fast local network
   share a proxy for bandwidth and speed savings; work is ongoing in this direction.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,7 +39,7 @@ for ONEREGISTRYIN in ${AUTH_REGISTRIES}; do
     AUTH_HOST=$(echo -n ${ONEREGISTRY} | cut -d ":" -f 1 | xargs)
     AUTH_USER=$(echo -n ${ONEREGISTRY} | cut -d ":" -f 2 | xargs)
     AUTH_PASS=$(echo -n ${ONEREGISTRY} | cut -d ":" -f 3 | xargs)
-    AUTH_BASE64=$(echo -n ${AUTH_USER}:${AUTH_PASS} | base64 | xargs)
+    AUTH_BASE64=$(echo -n ${AUTH_USER}:${AUTH_PASS} | base64 -w0 | xargs)
     echo "Adding Auth for registry '${AUTH_HOST}' with user '${AUTH_USER}'."
     echo "\"${AUTH_HOST}\" \"${AUTH_BASE64}\";" >> /etc/nginx/docker.auth.map
 done


### PR DESCRIPTION
if encoded AUTH_USER:AUTH_PASS is large enough to not fit 80 characters length.
Add coreutils package to provide the right version of base64 binary.