### PR TITLE
access logs log_format to json

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -15,7 +15,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    # Use a json debug-oriented logging format.
+    # Use a debug-oriented logging format.
     log_format debugging escape=json
       '{'
         '"access_time":"$time_local",'

--- a/nginx.conf
+++ b/nginx.conf
@@ -15,30 +15,61 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    # Use a debug-oriented logging format.
-    log_format  debugging  '$remote_addr - $remote_user [$time_local] "$request" '
-    '$status $body_bytes_sent '
-    '"HOST: $host" "UPSTREAM: $upstream_addr" '
-    '"UPSTREAM-STATUS: $upstream_status" '
-    '"SSL-PROTO: $ssl_protocol" '
-    '"CONNECT-HOST: $connect_host" "CONNECT-PORT: $connect_port" "CONNECT-ADDR: $connect_addr" '
-    '"PROXY-HOST: $proxy_host" "UPSTREAM-REDIRECT: $upstream_http_location" "CACHE-STATUS: $upstream_cache_status" '
-    '"AUTH: $http_authorization" ' ;
-
-    log_format  debug_proxy  'CONNECTPROXY: $remote_addr - $remote_user [$time_local] "$request" '
-    '$status $body_bytes_sent '
-    '"HOST: $host" "UPSTREAM: $upstream_addr" '
-    '"UPSTREAM-STATUS: $upstream_status" '
-    '"SSL-PROTO: $ssl_protocol" '
-    '"CONNECT-HOST: $connect_host" "CONNECT-PORT: $connect_port" "CONNECT-ADDR: $connect_addr" "INTERCEPTED: $interceptedHost" '
-    '"PROXY-HOST: $proxy_host" "UPSTREAM-REDIRECT: $upstream_http_location" "CACHE-STATUS: $upstream_cache_status" '
-    '"AUTH: $http_authorization" ' ;
-
-    log_format  tweaked  '$upstream_cache_status [$time_local] "$uri" '
-    '$status $body_bytes_sent '
-    '"HOST:$host" '
-    '"PROXY-HOST:$proxy_host" "UPSTREAM:$upstream_addr" ';
-
+    # Use a json debug-oriented logging format.
+    log_format debugging escape=json
+      '{'
+        '"access_time":"$time_local",'
+        '"remote_addr":"$remote_addr",'
+        '"remote_user":"$remote_user",'
+        '"request":"$request",'
+        '"status":"$status",'
+        '"bytes_sent":"$body_bytes_sent",'
+        '"host":"$host",'
+        '"proxy_host":"$proxy_host",'
+        '"upstream":"$upstream_addr"'
+        '"upstream_status":"$upstream_status",'
+        '"ssl_protocol":"$ssl_protocol",'
+        '"connect_host":"$connect_host",'
+        '"connect_port":"$connect_port",'
+        '"connect_addr":"$connect_addr",'
+        '"upstream_http_location":"$upstream_http_location",'
+        '"upstream_cache_status":"$upstream_cache_status",'
+        '"http_authorization":"$http_authorization",'
+      '}'; 
+    
+    log_format debug_proxy escape=json
+      '{'
+        '"access_time":"$time_local",'
+        '"remote_addr":"$remote_addr",'
+        '"remote_user":"$remote_user",'
+        '"request":"$request",'
+        '"status":"$status",'
+        '"bytes_sent":"$body_bytes_sent",'
+        '"host":"$host",'
+        '"proxy_host":"$proxy_host",'
+        '"upstream":"$upstream_addr"'
+        '"upstream_status":"$upstream_status",'
+        '"ssl_protocol":"$ssl_protocol",'
+        '"connect_host":"$connect_host",'
+        '"connect_port":"$connect_port",'
+        '"connect_addr":"$connect_addr",'
+        '"upstream_http_location":"$upstream_http_location",'
+        '"upstream_cache_status":"$upstream_cache_status",'
+        '"http_authorization":"$http_authorization",'
+      '}'; 
+    
+    log_format tweaked escape=json
+      '{'
+        '"access_time":"$time_local",'
+        '"upstream_cache_status":"$upstream_cache_status",'
+        '"uri":"$uri",'
+        '"status":"$status",'
+        '"bytes_sent":"$body_bytes_sent",'
+        '"host":"$host",'
+        '"proxy_host":"$proxy_host",'
+        '"upstream":"$upstream_addr"'
+      '}';
+    
     keepalive_timeout  300;
     gzip  off;
 


### PR DESCRIPTION
Hi
:)
 I had asked about access logs in json format before, you mentioned I could do a PR.
This change I implemented gives me the output in json format.
looks something like this.
{"upstream_cache_status":"","access_time":"13/May/2020:15:25:30 +0000","uri":"/v2/library/centos/manifests/sha256:9e0c275e0bcb495773b10a18e499985d782810e47b4fce076422acb4bc3da3dd","status":"200","bytes_sent":"529","host":"registry-1.docker.io","proxy_host":"registry-1.docker.io","upstream":"18.213.137.78:443"}

In our case this is running on k8s.  I send this output to kibana in json.  Since its in json we can use  filters to get graphs and data.

