### PR TITLE
Cache immutable URLs and handle outages

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -224,15 +224,48 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
             return 405 "docker-registry-proxy: docker is trying to use v1 API. Either the image does not exist upstream, or you need to configure docker-registry-proxy to authenticate against $host";
         }
 
-        # for the /v2/..../blobs/.... URIs, do cache, and treat redirects.
-        location ~ ^/v2/(.*)/blobs/ {
+        # For blob requests by digest, do cache, and treat redirects.
+        location ~ ^/v2/(.*)/blobs/sha256:(.*) {
             proxy_pass https://$targetHost;
             proxy_cache cache;
             proxy_cache_key   $uri;
             proxy_intercept_errors on;
             error_page 301 302 307 = @handle_redirects;
         }
-
+        
+        # For manifest requests by digest, do cache, and treat redirects.
+        location ~ ^/v2/(.*)/manifests/sha256:(.*) {
+            proxy_pass https://$targetHost;
+            proxy_cache cache;
+            proxy_cache_key   $uri;
+            proxy_intercept_errors on;
+            error_page 301 302 307 = @handle_redirects;
+        }
+        
+        # Cache manifest requests that are not by digest (e.g. tags)
+        # Since these are mutable, we invalidate them immediately and keep them only in case the backend is down
+        location ~ ^/v2/(.*)/manifests/ {
+            proxy_pass https://$targetHost;
+            proxy_cache cache;
+            proxy_cache_key   $uri;
+            proxy_intercept_errors on;
+            proxy_cache_use_stale  error timeout http_500 http_502 http_504;
+            proxy_cache_valid any 1s;
+            error_page 301 302 307 = @handle_redirects;
+        }
+        
+        # Cache manifest requests that are not by digest (e.g. tags)
+        # Since these are mutable, we invalidate them immediately and keep them only in case the backend is down
+        location ~ ^/v2/(.*)/blobs/ {
+            proxy_pass https://$targetHost;
+            proxy_cache cache;
+            proxy_cache_key   $uri;
+            proxy_intercept_errors on;
+            proxy_cache_use_stale  error timeout http_500 http_502 http_504;
+            proxy_cache_valid 1s;
+            error_page 301 302 307 = @handle_redirects;
+        }
+        
         location @handle_redirects {
             #store the current state of the world so we can reuse it in a minute
             # We need to capture these values now, because as soon as we invoke

--- a/nginx.conf
+++ b/nginx.conf
@@ -249,19 +249,19 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
             proxy_cache cache;
             proxy_cache_key   $uri;
             proxy_intercept_errors on;
-            proxy_cache_use_stale  error timeout http_500 http_502 http_504;
-            proxy_cache_valid any 1s;
+            proxy_cache_use_stale  error timeout http_500 http_502 http_504 http_403;
+            proxy_cache_valid 1s;
             error_page 301 302 307 = @handle_redirects;
         }
         
-        # Cache manifest requests that are not by digest (e.g. tags)
+        # Cache blobs requests that are not by digest
         # Since these are mutable, we invalidate them immediately and keep them only in case the backend is down
         location ~ ^/v2/(.*)/blobs/ {
             proxy_pass https://$targetHost;
             proxy_cache cache;
             proxy_cache_key   $uri;
             proxy_intercept_errors on;
-            proxy_cache_use_stale  error timeout http_500 http_502 http_504;
+            proxy_cache_use_stale  error timeout http_500 http_502 http_504 http_403;
             proxy_cache_valid 1s;
             error_page 301 302 307 = @handle_redirects;
         }


### PR DESCRIPTION
1. Changes the blob cache to only cache by digest
2. Adds caching for manifests requested by digest
3. Cache but invalidate immediately (after 1s) mutable requests
4. Use invalidated cache (from 3) if the backend is down