### PR TITLE
Correct status code for rate limits

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -288,7 +288,7 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
             proxy_cache cache;
             proxy_cache_key   $uri;
             proxy_intercept_errors on;
-            proxy_cache_use_stale  error timeout http_500 http_502 http_504 http_403;
+            proxy_cache_use_stale  error timeout http_500 http_502 http_504 http_429;
             proxy_cache_valid 1s;
             error_page 301 302 307 = @handle_redirects;
         }
@@ -300,7 +300,7 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
             proxy_cache cache;
             proxy_cache_key   $uri;
             proxy_intercept_errors on;
-            proxy_cache_use_stale  error timeout http_500 http_502 http_504 http_403;
+            proxy_cache_use_stale  error timeout http_500 http_502 http_504 http_429;
             proxy_cache_valid 1s;
             error_page 301 302 307 = @handle_redirects;
         }


### PR DESCRIPTION
403 was not right here, should be 429.
Can test this with this repo: `ratelimitalways/test:latest`