### PR TITLE
Allow push

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,5 +94,8 @@ ENV MANIFEST_CACHE_SECONDARY_TIME="60d"
 # In the default config, :latest and other frequently-used tags will get this value.
 ENV MANIFEST_CACHE_DEFAULT_TIME="1h"
 
+# Should we allow actions different than pull, default to false.
+ENV ALLOW_PUSH="false"
+
 # Did you want a shell? Sorry, the entrypoint never returns, because it runs nginx itself. Use 'docker exec' if you need to mess around internally.
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,11 +41,9 @@ VOLUME /docker_mirror_cache
 VOLUME /ca
 
 # Add our configuration
-ADD nginx.conf \
-  nginx.manifest.common.conf \
-  nginx.manifest.stale.conf \
-  nginx.manifest.methods.conf \
-  /etc/nginx/
+ADD nginx.conf /etc/nginx/nginx.conf
+ADD nginx.manifest.common.conf /etc/nginx/nginx.manifest.common.conf
+ADD nginx.manifest.stale.conf /etc/nginx/nginx.manifest.stale.conf
 
 # Add our very hackish entrypoint and ca-building scripts, make them executable
 ADD entrypoint.sh /entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -121,6 +121,29 @@ echo "Manifest caching config: ---"
 cat /etc/nginx/nginx.manifest.caching.config.conf
 echo "---"
 
+if [[ "a${ALLOW_PUSH}" == "atrue" ]]; then
+    cat <<EOF > /etc/nginx/conf.d/allowed.methods.conf
+    # allow to upload big layers
+    client_max_body_size 0;
+
+    # only cache GET requests
+    proxy_cache_methods GET;
+EOF
+else
+    cat <<EOF > /etc/nginx/conf.d/allowed.methods.conf
+    # Block POST/PUT/DELETE. Don't use this proxy for pushing.
+    if ($request_method = POST) {
+        return 405 "POST method is not allowed";
+    }
+    if ($request_method = PUT) {
+        return 405 "PUT method is not allowed";
+    }
+    if ($request_method = DELETE) {
+        return 405  "DELETE method is not allowed";
+    }
+EOF
+fi
+
 # normally use non-debug version of nginx
 NGINX_BIN="/usr/sbin/nginx"
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -201,6 +201,9 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
         include /etc/nginx/caching.layer.listen;
         server_name _;
 
+        # allow to upload big layers
+        client_max_body_size 0;
+
         # Do some tweaked logging.
         access_log  /var/log/nginx/access.log  tweaked;
         set $docker_proxy_request_type "unknown";

--- a/nginx.conf
+++ b/nginx.conf
@@ -219,17 +219,6 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
         # Docker needs this. Don't ask.
         chunked_transfer_encoding on;
 
-        # Block POST/PUT/DELETE. Don't use this proxy for pushing.
-        if ($request_method = POST) {
-            return 405 "POST method is not allowed";
-        }
-        if ($request_method = PUT) {
-            return 405 "PUT method is not allowed";
-        }
-        if ($request_method = DELETE) {
-            return 405  "DELETE method is not allowed";
-        }
-
         proxy_read_timeout 900;
 
         # Use cache locking, with a huge timeout, so that multiple Docker clients asking for the same blob at the same time
@@ -239,6 +228,10 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
 
         # Cache all 200, 206 for 60 days.
         proxy_cache_valid 200 206 60d;
+
+        proxy_cache_convert_head off;
+        proxy_cache_methods GET;
+        proxy_cache_key $scheme$request_method$proxy_host$request_uri;
 
         # Some extra settings to maximize cache hits and efficiency
         proxy_force_ranges on;

--- a/nginx.conf
+++ b/nginx.conf
@@ -201,9 +201,6 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
         include /etc/nginx/caching.layer.listen;
         server_name _;
 
-        # allow to upload big layers
-        client_max_body_size 0;
-
         # Do some tweaked logging.
         access_log  /var/log/nginx/access.log  tweaked;
         set $docker_proxy_request_type "unknown";
@@ -234,10 +231,6 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
 
         # Cache all 200, 206 for 60 days.
         proxy_cache_valid 200 206 60d;
-
-        proxy_cache_convert_head off;
-        proxy_cache_methods GET;
-        proxy_cache_key $scheme$request_method$proxy_host$request_uri;
 
         # Some extra settings to maximize cache hits and efficiency
         proxy_force_ranges on;

--- a/nginx.conf
+++ b/nginx.conf
@@ -201,9 +201,6 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
         include /etc/nginx/caching.layer.listen;
         server_name _;
 
-        # allow to upload big layers
-        client_max_body_size 0;
-
         # Do some tweaked logging.
         access_log  /var/log/nginx/access.log  tweaked;
         set $docker_proxy_request_type "unknown";
@@ -222,6 +219,9 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
         # Docker needs this. Don't ask.
         chunked_transfer_encoding on;
 
+        # configuration of the different allowed methods
+        include "/etc/nginx/conf.d/allowed.methods.conf"
+
         proxy_read_timeout 900;
 
         # Use cache locking, with a huge timeout, so that multiple Docker clients asking for the same blob at the same time
@@ -231,10 +231,6 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
 
         # Cache all 200, 206 for 60 days.
         proxy_cache_valid 200 206 60d;
-
-        proxy_cache_convert_head off;
-        proxy_cache_methods GET;
-        proxy_cache_key $scheme$request_method$proxy_host$request_uri;
 
         # Some extra settings to maximize cache hits and efficiency
         proxy_force_ranges on;


### PR DESCRIPTION
Based on #17 adds additional modifications to actually allow pushing, with the changes there I was getting errors about not allowed methods.

Also doesn't restrict the size of the layers to be pushed, for my use case (proxy to be accessed from a private network) makes sense to have this in place, maybe not so much in a generic public network.

Happy to propose the changes to be added on top of #17 let me know what works better for you.