### PR TITLE
add ca_srl creation when custom cert and key are provided

### DIFF
--- a/create_ca_cert.sh
+++ b/create_ca_cert.sh
@@ -31,6 +31,9 @@ CA_SRL_FILE=/ca/ca.srl
 
 if [ -f "$CA_CRT_FILE" ] ; then
     logInfo "CA already exists. Good. We'll reuse it."
+    if [ ! -f "$CA_SRL_FILE" ] ; then
+        echo 01 > ${CA_SRL_FILE}
+    fi
 else
     logInfo "No CA was found. Generating one."
     logInfo "*** Please *** make sure to mount /ca as a volume -- if not, everytime this container starts, it will regenerate the CA and nothing will work."


### PR DESCRIPTION
With this change, users are able to use their own certs and keys with this project

With this change, the docker registry proxy can be used with Kubernetes where the cert and key can be stored as Kubernetes secrets and mounted into the /ca directory