### PR TITLE
Added CAserial input into openssl command

### DIFF
--- a/create_ca_cert.sh
+++ b/create_ca_cert.sh
@@ -82,7 +82,7 @@ EOF
 [[ ${DEBUG} -gt 0 ]] && openssl req -in ia.csr -noout -text
 
 logInfo "Sign the IA request with the CA cert and key, producing the IA cert"
-openssl x509 -req -days 730 -in ia.csr -CA ${CA_CRT_FILE} -CAkey ${CA_KEY_FILE} -out ia.crt -passin pass:foobar -extensions IA -extfile <(
+openssl x509 -req -days 730 -in ia.csr -CA ${CA_CRT_FILE} -CAkey ${CA_KEY_FILE} -CAserial ${CA_SRL_FILE} -out ia.crt -passin pass:foobar -extensions IA -extfile <(
 cat <<-EOF
 [req]
 distinguished_name = dn


### PR DESCRIPTION
Without this change, the CA_SRL_FILE path must be the same as the ca cert path


