### PR TITLE
Allow users to provide their own Docker credentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,8 @@ ENV ALLOW_OWN_AUTH="false"
 
 # Should we allow actions different than pull, default to false.
 ENV ALLOW_PUSH="false"
+# Should we allow push only with own authentication, default to false.
+ENV ALLOW_PUSH_WITH_OWN_AUTH="false"
 
 # If push is allowed, buffering requests can cause issues on slow upstreams.
 # If you have trouble pushing, set this to false first, then fix remainig timouts.

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,9 @@ ENV MANIFEST_CACHE_SECONDARY_TIME="60d"
 # In the default config, :latest and other frequently-used tags will get this value.
 ENV MANIFEST_CACHE_DEFAULT_TIME="1h"
 
+# Should we allow overridding with own authentication, default to false.
+ENV ALLOW_OWN_AUTH="false"
+
 # Should we allow actions different than pull, default to false.
 ENV ALLOW_PUSH="false"
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ for this to work it requires inserting a root CA certificate into system trusted
 - Expose port 3128 to the network
 - Map volume `/docker_mirror_cache` for up to `CACHE_MAX_SIZE` (32gb by default) of cached images across all cached registries
 - Map volume `/ca`, the proxy will store the CA certificate here across restarts. **Important** this is security sensitive.
+- Env `ALLOW_OWN_AUTH` (default `false`): Allow overridding the `AUTH_REGISTRIES` authentication with own Docker credentials if provided (to support `docker login` as another user).
 - Env `ALLOW_PUSH` : This bypasses the proxy when pushing, default to false - if kept to false, pushing will not work. For more info see this [commit](https://github.com/rpardini/docker-registry-proxy/commit/536f0fc8a078d03755f1ae8edc19a86fc4b37fcf).
 - Env `CACHE_MAX_SIZE` (default `32g`): set the max size to be used for caching local Docker image layers. Use [Nginx sizes](http://nginx.org/en/docs/syntax.html).
 - Env `ENABLE_MANIFEST_CACHE`, see the section on pull rate limiting.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ for this to work it requires inserting a root CA certificate into system trusted
 - Map volume `/docker_mirror_cache` for up to `CACHE_MAX_SIZE` (32gb by default) of cached images across all cached registries
 - Map volume `/ca`, the proxy will store the CA certificate here across restarts. **Important** this is security sensitive.
 - Env `ALLOW_OWN_AUTH` (default `false`): Allow overridding the `AUTH_REGISTRIES` authentication with own Docker credentials if provided (to support `docker login` as another user).
-- Env `ALLOW_PUSH` : This bypasses the proxy when pushing, default to false - if kept to false, pushing will not work. For more info see this [commit](https://github.com/rpardini/docker-registry-proxy/commit/536f0fc8a078d03755f1ae8edc19a86fc4b37fcf).
+- Env `ALLOW_PUSH` (default `false`): This bypasses the proxy when pushing, default to false - if kept to false, pushing will not work. For more info see this [commit](https://github.com/rpardini/docker-registry-proxy/commit/536f0fc8a078d03755f1ae8edc19a86fc4b37fcf).
+- Env `ALLOW_PUSH_WITH_OWN_AUTH` (default `false`): Allow bypassing the proxy when pushing only if own authentication is provided.
 - Env `CACHE_MAX_SIZE` (default `32g`): set the max size to be used for caching local Docker image layers. Use [Nginx sizes](http://nginx.org/en/docs/syntax.html).
 - Env `ENABLE_MANIFEST_CACHE`, see the section on pull rate limiting.
 - Env `REGISTRIES`: space separated list of registries to cache; no need to include DockerHub, its already done internally.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -151,6 +151,17 @@ echo -e "\nManifest caching config: ---\n"
 cat /etc/nginx/nginx.manifest.caching.config.conf
 echo "---"
 
+if [[ "a${ALLOW_OWN_AUTH}" == "atrue" ]]; then
+    cat << 'EOF' > /etc/nginx/conf.d/allowed_override_auth.conf
+    if ($http_authorization != "") {
+        # override with own authentication if provided
+        set $finalAuth $http_authorization;
+    }
+EOF
+else
+    echo '' > /etc/nginx/conf.d/allowed_override_auth.conf
+fi
+
 if [[ "a${ALLOW_PUSH}" == "atrue" ]]; then
     cat <<EOF > /etc/nginx/conf.d/allowed.methods.conf
     # allow to upload big layers

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -170,6 +170,31 @@ if [[ "a${ALLOW_PUSH}" == "atrue" ]]; then
     # only cache GET requests
     proxy_cache_methods GET;
 EOF
+elif [[ "a${ALLOW_PUSH_WITH_OWN_AUTH}" == "atrue" ]]; then
+    cat << 'EOF' > /etc/nginx/conf.d/allowed.methods.conf
+    # Block POST/PUT/DELETE if own authentication is not provided.
+    set $combined_ha_rm "$http_authorization$request_method";
+    if ($combined_ha_rm = POST) {
+        return 405 "POST method is not allowed";
+    }
+    if ($combined_ha_rm = PUT) {
+        return 405 "PUT method is not allowed";
+    }
+    if ($combined_ha_rm = DELETE) {
+        return 405  "DELETE method is not allowed";
+    }
+
+    if ($http_authorization != "") {
+        # override with own authentication if provided
+        set $finalAuth $http_authorization;
+    }
+
+    # allow to upload big layers
+    client_max_body_size 0;
+
+    # only cache GET requests
+    proxy_cache_methods GET;
+EOF
 else
     cat << 'EOF' > /etc/nginx/conf.d/allowed.methods.conf
     # Block POST/PUT/DELETE. Don't use this proxy for pushing.

--- a/nginx.conf
+++ b/nginx.conf
@@ -253,6 +253,7 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
         proxy_ignore_headers   X-Accel-Expires Expires Cache-Control Set-Cookie;
 
         # Add the authentication info, if the map matched the target domain.
+        include "/etc/nginx/conf.d/allowed_override_auth.conf";
         proxy_set_header Authorization $finalAuth;
 
         # Use SNI during the TLS handshake with the upstream.


### PR DESCRIPTION
This PR adds two configurable options that allow users to provide their own Docker credentials:

- Env `ALLOW_OWN_AUTH` (default `false`): Allow overriding the `AUTH_REGISTRIES` authentication with own Docker credentials if provided (to support `docker login` as another user). (Fixes https://github.com/rpardini/docker-registry-proxy/issues/61)
- Env `ALLOW_PUSH_WITH_OWN_AUTH` (default `false`): Allow bypassing the proxy when pushing only if own authentication is provided.