### PR TITLE
Disable conversion of HEAD method to GET

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -244,6 +244,16 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
         proxy_ignore_client_abort on;
         proxy_cache_revalidate on;
 
+        # Avoid conversion of HEAD method to GET
+        proxy_cache_convert_head off;
+        # HEAD requests are to be cached separately from GET, so they need a different cache key.
+        # To avoid a breaking change in cache keys (which would invalidate existing caches), we keep the normal URI
+        # for GET requests as key, but use a prefix for HEAD.
+        set $docker_proxy_cache_prefix "";
+        if ($request_method = HEAD) {
+            set $docker_proxy_cache_prefix "HEAD:";
+        }
+
         # Hide/ignore headers from caching. S3 especially likes to send Expires headers in the past in some situations.
         proxy_hide_header      Set-Cookie;
         proxy_ignore_headers   X-Accel-Expires Expires Cache-Control Set-Cookie;
@@ -307,7 +317,7 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
             proxy_cache cache;
             # But we store the result with the cache key of the original request URI
             # so that future clients don't need to follow the redirect too
-            proxy_cache_key $original_uri;
+            proxy_cache_key $docker_proxy_cache_prefix$original_uri;
         }
 
         # by default, dont cache anything.

--- a/nginx.manifest.common.conf
+++ b/nginx.manifest.common.conf
@@ -3,6 +3,6 @@
     add_header X-Docker-Registry-Proxy-Cache-Type "$docker_proxy_request_type";
     proxy_pass https://$targetHost;
     proxy_cache cache;
-    proxy_cache_key   $uri;
+    proxy_cache_key   $docker_proxy_cache_prefix$uri;
     proxy_intercept_errors on;
     error_page 301 302 307 = @handle_redirects;


### PR DESCRIPTION
This PR disables the conversion of request method HEAD to GET when caching applies. As the documentation at http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_convert_head suggests, the cache key is extended with the method.
In order to not invalidate existing caches, I decided to keep the cache keys for GET as they are. Only HEAD requests will use a "HEAD:" prefix. This could be cleaned up later when a breaking change needs to be made anyway (e.g., why don't we have the FQDN or registry name in the cache key?).

* This fixes https://github.com/rpardini/docker-registry-proxy/issues/88.
* This also addresses earlier problems like e.g. https://github.com/rpardini/docker-registry-proxy/pull/59#pullrequestreview-530081801