### PR TITLE
Feature/configure blob caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,6 @@ VOLUME /ca
 # Add our configuration
 ADD nginx.conf /etc/nginx/nginx.conf
 ADD nginx.manifest.common.conf /etc/nginx/nginx.manifest.common.conf
-ADD nginx.manifest.stale.conf /etc/nginx/nginx.manifest.stale.conf
 
 # Add our very hackish entrypoint and ca-building scripts, make them executable
 ADD entrypoint.sh /entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -111,6 +111,7 @@ echo -n "" >/etc/nginx/nginx.manifest.caching.config.conf
     # First tier caching of manifests; configure via MANIFEST_CACHE_PRIMARY_REGEX and MANIFEST_CACHE_PRIMARY_TIME
     location ~ ^/v2/(.*)/manifests/${MANIFEST_CACHE_PRIMARY_REGEX} {
         set \$docker_proxy_request_type "manifest-primary";
+        set \$cache_key \$uri;
         proxy_cache_valid ${MANIFEST_CACHE_PRIMARY_TIME};
         include "/etc/nginx/nginx.manifest.stale.conf";
     }
@@ -120,6 +121,7 @@ EOD
     # Secondary tier caching of manifests; configure via MANIFEST_CACHE_SECONDARY_REGEX and MANIFEST_CACHE_SECONDARY_TIME
     location ~ ^/v2/(.*)/manifests/${MANIFEST_CACHE_SECONDARY_REGEX} {
         set \$docker_proxy_request_type "manifest-secondary";
+        set \$cache_key \$uri;
         proxy_cache_valid ${MANIFEST_CACHE_SECONDARY_TIME};
         include "/etc/nginx/nginx.manifest.stale.conf";
     }
@@ -129,6 +131,7 @@ EOD
     # Default tier caching for manifests. Caches for ${MANIFEST_CACHE_DEFAULT_TIME} (from MANIFEST_CACHE_DEFAULT_TIME)
     location ~ ^/v2/(.*)/manifests/ {
         set \$docker_proxy_request_type "manifest-default";
+        set \$cache_key \$uri;
         proxy_cache_valid ${MANIFEST_CACHE_DEFAULT_TIME};
         include "/etc/nginx/nginx.manifest.stale.conf";
     }
@@ -138,6 +141,7 @@ EOD
     # Manifest caching is disabled. Enable it with ENABLE_MANIFEST_CACHE=true
     location ~ ^/v2/(.*)/manifests/ {
         set \$docker_proxy_request_type "manifest-default-disabled";
+        set \$cache_key \$uri;
         proxy_cache_valid 0s;
         include "/etc/nginx/nginx.manifest.stale.conf";
     }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -119,7 +119,7 @@ echo -n "" >/etc/nginx/nginx.manifest.caching.config.conf
     location ~ ^/v2/(.*)/manifests/${MANIFEST_CACHE_PRIMARY_REGEX} {
         set \$docker_proxy_request_type "manifest-primary";
         proxy_cache_valid ${MANIFEST_CACHE_PRIMARY_TIME};
-        include "/etc/nginx/nginx.manifest.stale.conf";
+        include "/etc/nginx/nginx.manifest.common.conf";
     }
 EOD
 
@@ -128,7 +128,7 @@ EOD
     location ~ ^/v2/(.*)/manifests/${MANIFEST_CACHE_SECONDARY_REGEX} {
         set \$docker_proxy_request_type "manifest-secondary";
         proxy_cache_valid ${MANIFEST_CACHE_SECONDARY_TIME};
-        include "/etc/nginx/nginx.manifest.stale.conf";
+        include "/etc/nginx/nginx.manifest.common.conf";
     }
 EOD
 
@@ -137,7 +137,7 @@ EOD
     location ~ ^/v2/(.*)/manifests/ {
         set \$docker_proxy_request_type "manifest-default";
         proxy_cache_valid ${MANIFEST_CACHE_DEFAULT_TIME};
-        include "/etc/nginx/nginx.manifest.stale.conf";
+        include "/etc/nginx/nginx.manifest.common.conf";
     }
 EOD
 
@@ -146,7 +146,7 @@ EOD
     location ~ ^/v2/(.*)/manifests/ {
         set \$docker_proxy_request_type "manifest-default-disabled";
         proxy_cache_valid 0s;
-        include "/etc/nginx/nginx.manifest.stale.conf";
+        include "/etc/nginx/nginx.manifest.common.conf";
     }
 EOD
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -99,10 +99,17 @@ echo "error_log  /var/log/nginx/error.log warn;" > /etc/nginx/error.log.debug.wa
 
 # Set Docker Registry cache size, by default, 32 GB ('32g')
 CACHE_MAX_SIZE=${CACHE_MAX_SIZE:-32g}
+# Set Docker Registry cache max age, by default, 60 days ('60d')
+CACHE_MAX_AGE=${CACHE_MAX_AGE:-60d}
 
 # The cache directory. This can get huge. Better to use a Docker volume pointing here!
 # Set to 32gb which should be enough
-echo "proxy_cache_path /docker_mirror_cache levels=1:2 max_size=$CACHE_MAX_SIZE inactive=60d keys_zone=cache:10m use_temp_path=off;" > /etc/nginx/conf.d/cache_max_size.conf
+echo "proxy_cache_path /docker_mirror_cache levels=1:2 max_size=$CACHE_MAX_SIZE inactive=$CACHE_MAX_AGE keys_zone=cache:10m use_temp_path=off;" > /etc/nginx/conf.d/proxy_cache_path.conf
+
+# Set Docker Registry cache valid duration, by default, 60 days ('60d')
+CACHE_VALIDITY_PERIOD=${CACHE_VALIDITY_PERIOD:-60d}
+# Cache all 200, 206 for CACHE_VALIDITY_PERIOD.
+echo "proxy_cache_valid 200 206 $CACHE_VALIDITY_PERIOD;" > /etc/nginx/conf.d/proxy_cache_valid.conf
 
 # Manifest caching configuration. We generate config based on the environment vars.
 echo -n "" >/etc/nginx/nginx.manifest.caching.config.conf

--- a/nginx.conf
+++ b/nginx.conf
@@ -262,6 +262,7 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
         # For blob requests by digest, do cache, and treat redirects.
         location ~ ^/v2/(.*)/blobs/sha256:(.*) {
             set $docker_proxy_request_type "blob-by-digest";
+            set $cache_key $2;
             include "/etc/nginx/nginx.manifest.common.conf";
         }
 
@@ -269,6 +270,7 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
         # These are some of the requests that DockerHub will throttle.
         location ~ ^/v2/(.*)/manifests/sha256:(.*) {
             set $docker_proxy_request_type "manifest-by-digest";
+            set $cache_key $uri;
             include "/etc/nginx/nginx.manifest.common.conf";
         }
 
@@ -281,6 +283,7 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
         # Since these are mutable, we invalidate them immediately and keep them only in case the backend is down
         location ~ ^/v2/(.*)/blobs/ {
             set $docker_proxy_request_type "blob-mutable";
+            set $cache_key $uri;
             proxy_cache_valid 0s;
             include "/etc/nginx/nginx.manifest.stale.conf";
         }

--- a/nginx.conf
+++ b/nginx.conf
@@ -79,7 +79,7 @@ http {
     gzip  off;
 
     # Entrypoint generates the proxy_cache_path here, so it is configurable externally.
-    include /etc/nginx/conf.d/cache_max_size.conf;
+    include /etc/nginx/conf.d/proxy_cache_path.conf;
 
     # Just in case you want to rewrite some hosts. Default maps directly.
     map $host $targetHost {
@@ -232,8 +232,8 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
         proxy_cache_lock on;
         proxy_cache_lock_timeout 880s;
 
-        # Cache all 200, 206 for 60 days.
-        proxy_cache_valid 200 206 60d;
+        # Entrypoint generates the proxy_cache_valid here, so it is configurable externally.
+        include /etc/nginx/conf.d/proxy_cache_valid.conf;
 
         # Some extra settings to maximize cache hits and efficiency
         proxy_force_ranges on;

--- a/nginx.conf
+++ b/nginx.conf
@@ -282,7 +282,7 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
         location ~ ^/v2/(.*)/blobs/ {
             set $docker_proxy_request_type "blob-mutable";
             proxy_cache_valid 0s;
-            include "/etc/nginx/nginx.manifest.stale.conf";
+            include "/etc/nginx/nginx.manifest.common.conf";
         }
 
         location @handle_redirects {

--- a/nginx.manifest.common.conf
+++ b/nginx.manifest.common.conf
@@ -3,6 +3,6 @@
     add_header X-Docker-Registry-Proxy-Cache-Type "$docker_proxy_request_type";
     proxy_pass https://$targetHost;
     proxy_cache cache;
-    proxy_cache_key   $uri;
+    proxy_cache_key   $cache_key;
     proxy_intercept_errors on;
     error_page 301 302 307 = @handle_redirects;

--- a/nginx.manifest.common.conf
+++ b/nginx.manifest.common.conf
@@ -4,5 +4,6 @@
     proxy_pass https://$targetHost;
     proxy_cache cache;
     proxy_cache_key   $uri;
+    proxy_cache_use_stale  error timeout http_500 http_502 http_504 http_429;
     proxy_intercept_errors on;
     error_page 301 302 307 = @handle_redirects;

--- a/nginx.manifest.stale.conf
+++ b/nginx.manifest.stale.conf
@@ -1,3 +1,0 @@
-    # Just like the common block, but adds proxy_cache_use_stale
-    include "/etc/nginx/nginx.manifest.common.conf";
-    proxy_cache_use_stale  error timeout http_500 http_502 http_504 http_429;


### PR DESCRIPTION
This PR implements the following:

### What:
1. Enable configuration of 'proxy_cache_valid' age with CACHE_VALIDITY_PERIOD var (defaults to 60d)
2. Enable configuration of 'proxy_cache_path' 'inactive' setting with CACHE_MAX_AGE var (defaults to 60d)
3. Allows serving from STALE cache for non-manifest layers (eg: blob) when upstream is not available (e.g. connectivity issues / airgapped solution)

### Why:
1. We want to be able to pull images and cache them for variable periods of time (e.g. forever). 
2. We want to limit the impact of upstream outages by always allowing serving of STALE content if there are upstream issues

Comments welcome

Happy to update readme post discussion