### PR TITLE
Accept TLSv1.3

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -149,7 +149,8 @@ http {
         proxy_connect_allow all;
         proxy_connect_address $interceptedHost;
         proxy_max_temp_file_size 0;
-
+        proxy_ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+      
         # We need to resolve the real names of our proxied servers.
         #resolver 8.8.8.8 4.2.2.2 ipv6=off; # Avoid ipv6 addresses for now
         include /etc/nginx/resolvers.conf;

--- a/nginx.manifest.common.conf
+++ b/nginx.manifest.common.conf
@@ -6,3 +6,4 @@
     proxy_cache_key   $uri;
     proxy_intercept_errors on;
     error_page 301 302 307 = @handle_redirects;
+    proxy_ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;


### PR DESCRIPTION
Configure `nginx` to be able to deal with upstream server with all TLS version from 1 to 1.3.