### PR TITLE
add option to disable request buffering.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,11 @@ ENV MANIFEST_CACHE_DEFAULT_TIME="1h"
 # Should we allow actions different than pull, default to false.
 ENV ALLOW_PUSH="false"
 
+# If push is allowed, buffering requests can cause issues on slow upstreams.
+# If you have trouble pushing, set this to false first, then fix remainig timouts.
+# Default is true to not change default behavior.
+ENV PROXY_REQUEST_BUFFERING="true"
+
 # Timeouts
 # ngx_http_core_module
 ENV SEND_TIMEOUT="60s"

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ for this to work it requires inserting a root CA certificate into system trusted
   - `hostname`s listed here should be listed in the REGISTRIES environment as well, so they can be intercepted.
 - Env `AUTH_REGISTRIES_DELIMITER` to change the separator between authentication info. By default, a space: "` `". If you use keys that contain spaces (as with Google Cloud Registry), you should update this variable, e.g. setting it to `AUTH_REGISTRIES_DELIMITER=";;;"`. In that case, `AUTH_REGISTRIES` could contain something like `registry1.com:user1:pass1;;;registry2.com:user2:pass2`.
 - Env `AUTH_REGISTRY_DELIMITER` to change the separator between authentication info *parts*. By default, a colon: "`:`". If you use keys that contain single colons, you should update this variable, e.g. setting it to `AUTH_REGISTRIES_DELIMITER=":::"`. In that case, `AUTH_REGISTRIES` could contain something like `registry1.com:::user1:::pass1 registry2.com:::user2:::pass2`.
+- Env `PROXY_REQUEST_BUFFERING`: If push is allowed, buffering requests can cause issues on slow upstreams.
+If you have trouble pushing, set this to `false` first, then fix remainig timeouts.
+Default is `true` to not change default behavior.
+ENV PROXY_REQUEST_BUFFERING="true"
 - Timeouts ENVS - all of them can pe specified to control different timeouts, and if not set, the defaults will be the ones from `Dockerfile`. The directives will be added into `http` block.:
   - SEND_TIMEOUT : see [send_timeout](http://nginx.org/en/docs/http/ngx_http_core_module.html#send_timeout)
   - CLIENT_BODY_TIMEOUT : see [client_body_timeout](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_timeout)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -254,6 +254,20 @@ echo -e "\nTimeout configs: ---"
 cat /etc/nginx/nginx.timeouts.config.conf
 echo -e "---\n"
 
+# Request buffering
+echo "" > /etc/nginx/proxy.request.buffering.conf
+if [[ "a${PROXY_REQUEST_BUFFERING}" == "afalse" ]]; then
+  cat << EOD > /etc/nginx/proxy.request.buffering.conf
+  proxy_max_temp_file_size 0;
+  proxy_request_buffering off;
+  proxy_http_version 1.1;
+EOD
+fi
+
+echo -e "\nRequest buffering: ---"
+cat /etc/nginx/proxy.request.buffering.conf
+echo -e "---\n"
+
 # Upstream SSL verification.
 echo "" > /etc/nginx/docker.verify.ssl.conf
 if [[ "a${VERIFY_SSL}" == "atrue" ]]; then

--- a/nginx.conf
+++ b/nginx.conf
@@ -227,6 +227,9 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
 
         proxy_read_timeout 900;
 
+        # Request buffering
+        include /etc/nginx/proxy.request.buffering.conf;
+
         # Use cache locking, with a huge timeout, so that multiple Docker clients asking for the same blob at the same time
         # will wait for the first to finish instead of doing multiple upstream requests.
         proxy_cache_lock on;


### PR DESCRIPTION
If push is allowed, buffering requests can cause issues on slow upstreams.
The put requests pile up, and since `proxy_ignore_client_abort` is on...
...the push fails.

If you have trouble pushing, set `PROXY_REQUEST_BUFFERING`to false, then fix
remainig issues/timeouts.

Default is true to not change default behavior.