### PR TITLE
add option to change cache behavior (CACHE_GREEDY_MODE) 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,9 @@ ENV ALLOW_PUSH="false"
 # Default is true to not change default behavior.
 ENV PROXY_REQUEST_BUFFERING="true"
 
+# WARNING changing this setting invalidates your cache
+ENV CACHE_GREEDY_MODE="true"
+
 # Timeouts
 # ngx_http_core_module
 ENV SEND_TIMEOUT="60s"

--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ for this to work it requires inserting a root CA certificate into system trusted
 - Env `PROXY_REQUEST_BUFFERING`: If push is allowed, buffering requests can cause issues on slow upstreams.
 If you have trouble pushing, set this to `false` first, then fix remainig timeouts.
 Default is `true` to not change default behavior.
-ENV PROXY_REQUEST_BUFFERING="true"
 - Timeouts ENVS - all of them can pe specified to control different timeouts, and if not set, the defaults will be the ones from `Dockerfile`. The directives will be added into `http` block.:
   - SEND_TIMEOUT : see [send_timeout](http://nginx.org/en/docs/http/ngx_http_core_module.html#send_timeout)
   - CLIENT_BODY_TIMEOUT : see [client_body_timeout](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_timeout)

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ for this to work it requires inserting a root CA certificate into system trusted
 - Env `PROXY_REQUEST_BUFFERING`: If push is allowed, buffering requests can cause issues on slow upstreams.
 If you have trouble pushing, set this to `false` first, then fix remainig timeouts.
 Default is `true` to not change default behavior.
+- Env `CACHE_GREEDY_MODE`: In greedy mode a layer exist only once in the cache, and regardless which repository it is initially from, each repository get a hit on this layer now. This is the most space efficient way.  
+Pitfall: You can not push images that reuse layers from a differnt registry (`ALLOW_PUSH=true`).
+Set `CACHE_GREEDY_MODE=false` to enable this.
+With `CACHE_GREEDY_MODE=false` each registry have its own cache.  
+WARNING: Changing this setting invalitates your cache.  
+Default is `true` to not change default behavior.
 - Timeouts ENVS - all of them can pe specified to control different timeouts, and if not set, the defaults will be the ones from `Dockerfile`. The directives will be added into `http` block.:
   - SEND_TIMEOUT : see [send_timeout](http://nginx.org/en/docs/http/ngx_http_core_module.html#send_timeout)
   - CLIENT_BODY_TIMEOUT : see [client_body_timeout](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_timeout)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -268,6 +268,22 @@ echo -e "\nRequest buffering: ---"
 cat /etc/nginx/proxy.request.buffering.conf
 echo -e "---\n"
 
+# Cache greedy mode
+echo "" > /etc/nginx/cache.greedy.mode.conf
+if [[ "a${CACHE_GREEDY_MODE}" == "afalse" ]]; then
+  cat << EOD > /etc/nginx/cache.greedy.mode.conf
+  proxy_cache_key   "\$host \$uri";
+EOD
+else
+  cat << EOD > /etc/nginx/cache.greedy.mode.conf
+  proxy_cache_key   \$uri;
+EOD
+fi
+
+echo -e "\nCache greedy mode is '$CACHE_GREEDY_MODE' ---"
+cat /etc/nginx/cache.greedy.mode.conf
+echo -e "---\n"
+
 # Upstream SSL verification.
 echo "" > /etc/nginx/docker.verify.ssl.conf
 if [[ "a${VERIFY_SSL}" == "atrue" ]]; then

--- a/nginx.manifest.common.conf
+++ b/nginx.manifest.common.conf
@@ -3,6 +3,6 @@
     add_header X-Docker-Registry-Proxy-Cache-Type "$docker_proxy_request_type";
     proxy_pass https://$targetHost;
     proxy_cache cache;
-    proxy_cache_key   $uri;
+    include "/etc/nginx/cache.greedy.mode.conf";
     proxy_intercept_errors on;
     error_page 301 302 307 = @handle_redirects;


### PR DESCRIPTION
In default mode a layer exist only once in the cache, and regardless
which repository it is initially from, each repository get a hit on
this layer now.
Pitfall: You can not push images that reuse layers from a different
registry (`ALLOW_PUSH=true`).
Setting this option to 'false' adds the host to the cache key to solve this.

Default is `true` to not change default behavior.
WARNING: Changing this setting invalidates your cache!