### PR TITLE
disable IPv6 via environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ ENV PROXY_REQUEST_BUFFERING="true"
   - PROXY_CONNECT_READ_TIMEOUT : see [proxy_connect_read_timeout](https://github.com/chobits/ngx_http_proxy_connect_module#proxy_connect_read_timeout)
   - PROXY_CONNECT_CONNECT_TIMEOUT : see [proxy_connect_connect_timeout](https://github.com/chobits/ngx_http_proxy_connect_module#proxy_connect_connect_timeout)
   - PROXY_CONNECT_SEND_TIMEOUT : see [proxy_connect_send_timeout](https://github.com/chobits/ngx_http_proxy_connect_module#proxy_connect_send_timeout))
+- Env `DISABLE_IPV6`: If set to `true`, prevents nginx from getting IPv6 addresses from the resolver without needing a [custom resolver config](#custom_nginx_resolvers_configuration)
 
 
 ### Simple (no auth, all cache)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,6 +33,10 @@ confpath=/etc/nginx/resolvers.conf
 if [ ! -e $confpath ]
 then
     echo "Using auto-determined resolver '$conf' via '$confpath'"
+    if [[ "a${DISABLE_IPV6}" == "atrue" ]]; then
+      echo "Disabling IPv6 in '$confpath'"
+      conf="${conf%;*} ipv6=off;"
+    fi
     echo "$conf" > $confpath
 else
     echo "Not using resolver config, keep existing '$confpath' -- mounted by user?"


### PR DESCRIPTION
I was having the same problem as in issue #108, but I'd prefer not to have to create a custom resolver configuration for Nginx. Things are simpler if `entrypoint.sh` handles things and the container sorts itself out.

This PR implements a check for the env variable and the appending of `ipv6=off` to the resolver string if appropriate. I've tried to keep it in line with your coding style elsewhere in `entrypoint.sh`.

There's also an addition to `README.md` regarding the variable, but I'm not sure what to do about the link I included there.

I was initially looking at the `README.md` in PR #109, so I linked to the `Custom nginx resolvers configuration` heading. That PR hasn't been merged yet, but I left the link in under the assumption it will become functional at some future point.

I'm just not sure if that's the best way to go about things..? I'm happy to remove the link and rebase this PR if you'd like.