### PR TITLE
Allow proxying to any destination port number (not 443 only)

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -142,6 +142,7 @@ http {
         set $docker_proxy_request_type "unknown-connect";
 
         proxy_connect;
+        proxy_connect_allow all;
         proxy_connect_address $interceptedHost;
         proxy_max_temp_file_size 0;
 


### PR DESCRIPTION
The proxy refused to connect to a registry that was hosted on
a port other than 443. For example, I was not able to connect
to my registry that is hosted on port 5002:

$ https_proxy=proxy.lab.example.com:3128 curl -v https://registry.lab.example.com:5002
* Uses proxy env variable https_proxy == 'proxy.lab.example.com:3128'
*   Trying 192.168.140.1:3128...
* Connected to proxy.lab.example.com (192.168.140.1) port 3128 (#0)
* allocate connect buffer!
* Establish HTTP proxy tunnel to registry.lab.example.com:5002
> CONNECT registry.lab.example.com:5002 HTTP/1.1
> Host: registry.lab.example.com:5002
> User-Agent: curl/7.74.0
> Proxy-Connection: Keep-Alive
>
< HTTP/1.1 403 Forbidden
< Server: nginx/1.20.1
< Date: Thu, 11 Aug 2022 15:12:23 GMT
< Content-Type: text/html
< Content-Length: 153
< Connection: keep-alive
<
* Received HTTP code 403 from proxy after CONNECT
* CONNECT phase completed!
* Closing connection 0
curl: (56) Received HTTP code 403 from proxy after CONNECT

The proxy refused to pass through connections to URLs that used
port other than 443. For example, trying to connect to port 8443:

$ https_proxy=proxy.lab.example.com:3128 curl -v https://google.com:8443
* Uses proxy env variable https_proxy == 'proxy.lab.example.com:3128'
*   Trying 192.168.140.1:3128...
* Connected to proxy.lab.example.com (192.168.140.1) port 3128 (#0)
* allocate connect buffer!
* Establish HTTP proxy tunnel to google.com:8443
> CONNECT google.com:8443 HTTP/1.1
> Host: google.com:8443
> User-Agent: curl/7.74.0
> Proxy-Connection: Keep-Alive
>
< HTTP/1.1 403 Forbidden
< Server: nginx/1.20.1
< Date: Thu, 11 Aug 2022 16:05:52 GMT
< Content-Type: text/html
< Content-Length: 153
< Connection: keep-alive
<
* Received HTTP code 403 from proxy after CONNECT
* CONNECT phase completed!
* Closing connection 0
curl: (56) Received HTTP code 403 from proxy after CONNECT

This commit fixes the issue by configuring the proxy_connect_allow
paramater to allow connecting to any destination port number. By
default only port 443 and 563 were allowed. See also documentation
here:

https://github.com/chobits/ngx_http_proxy_connect_module#proxy_connect_allow