### PR TITLE
Mitmproxy won't start due to soft_unicode removed from markupsafe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV DO_DEBUG_BUILD="$DEBUG_BUILD"
 # Build mitmproxy via pip. This is heavy, takes minutes do build and creates a 90mb+ layer. Oh well.
 RUN [[ "a$DO_DEBUG_BUILD" == "a1" ]] && { echo "Debug build ENABLED." \
  && apk add --no-cache --update su-exec git g++ libffi libffi-dev libstdc++ openssl-dev python3 python3-dev py3-pip py3-wheel py3-six py3-idna py3-certifi py3-setuptools \
- && LDFLAGS=-L/lib pip install mitmproxy==5.2 \
+ && LDFLAGS=-L/lib pip install MarkupSafe==2.0.1 mitmproxy==5.2 \
  && apk del --purge git g++ libffi-dev openssl-dev python3-dev py3-pip py3-wheel \
  && rm -rf ~/.cache/pip \
  ; } || { echo "Debug build disabled." ; }


### PR DESCRIPTION
After building the debug image and trying to run it, the mitproxy
would fail to start:

Traceback (most recent call last):
  File "/usr/bin/mitmweb", line 8, in <module>
    sys.exit(mitmweb())
  File "/usr/lib/python3.8/site-packages/mitmproxy/tools/_main.py", line 172, in mitmweb
    from mitmproxy.tools import web
  File "/usr/lib/python3.8/site-packages/mitmproxy/tools/web/__init__.py", line 1, in <module>
    from mitmproxy.tools.web import master
  File "/usr/lib/python3.8/site-packages/mitmproxy/tools/web/master.py", line 5, in <module>
    from mitmproxy import addons
  File "/usr/lib/python3.8/site-packages/mitmproxy/addons/__init__.py", line 12, in <module>
    from mitmproxy.addons import onboarding
  File "/usr/lib/python3.8/site-packages/mitmproxy/addons/onboarding.py", line 2, in <module>
    from mitmproxy.addons.onboardingapp import app
  File "/usr/lib/python3.8/site-packages/mitmproxy/addons/onboardingapp/__init__.py", line 3, in <module>
    from flask import Flask, render_template
  File "/usr/lib/python3.8/site-packages/flask/__init__.py", line 14, in <module>
    from jinja2 import escape
  File "/usr/lib/python3.8/site-packages/jinja2/__init__.py", line 12, in <module>
    from .environment import Environment
  File "/usr/lib/python3.8/site-packages/jinja2/environment.py", line 25, in <module>
    from .defaults import BLOCK_END_STRING
  File "/usr/lib/python3.8/site-packages/jinja2/defaults.py", line 3, in <module>
    from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
  File "/usr/lib/python3.8/site-packages/jinja2/filters.py", line 13, in <module>
    from markupsafe import soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/usr/lib/python3.8/site-packages/markupsafe/__init__.py)

Fixed the issue by explicitly requiring an older version of MarkupSafe.

The issue is related to:
https://github.com/pallets/markupsafe/issues/282