### PR TITLE
Add DISABLE_IPV6 to ignore AAAA records when proxying requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,5 +117,8 @@ ENV PROXY_CONNECT_READ_TIMEOUT="60s"
 ENV PROXY_CONNECT_CONNECT_TIMEOUT="60s"
 ENV PROXY_CONNECT_SEND_TIMEOUT="60s"
 
+# Disable use of IPv6 hosts for outbound proxy requests if set to true
+ENV DISABLE_IPV6="false"
+
 # Did you want a shell? Sorry, the entrypoint never returns, because it runs nginx itself. Use 'docker exec' if you need to mess around internally.
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ ENV PROXY_REQUEST_BUFFERING="true"
   - PROXY_CONNECT_READ_TIMEOUT : see [proxy_connect_read_timeout](https://github.com/chobits/ngx_http_proxy_connect_module#proxy_connect_read_timeout)
   - PROXY_CONNECT_CONNECT_TIMEOUT : see [proxy_connect_connect_timeout](https://github.com/chobits/ngx_http_proxy_connect_module#proxy_connect_connect_timeout)
   - PROXY_CONNECT_SEND_TIMEOUT : see [proxy_connect_send_timeout](https://github.com/chobits/ngx_http_proxy_connect_module#proxy_connect_send_timeout))
+- Env `DISABLE_IPV6`: If you have problems with `nginx` attempting to connect to hosts over IPv6 but your network doesn't properly support IPv6, set this to `true` to ignore IPv6 AAAA records in DNS responses.
 
 
 ### Simple (no auth, all cache)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,11 @@ echo "DEBUG, determined RESOLVERS from /etc/resolv.conf: '$RESOLVERS'"
 conf=""
 for ONE_RESOLVER in ${RESOLVERS}; do
 	echo "Possible resolver: $ONE_RESOLVER"
-	conf="resolver $ONE_RESOLVER; "
+	if [[ "a${DISABLE_IPV6}" == "atrue" ]]; then
+		conf="resolver $ONE_RESOLVER ipv6=off; "
+	else
+		conf="resolver $ONE_RESOLVER; "
+	fi
 done
 
 echo "Final chosen resolver: $conf"


### PR DESCRIPTION
I was getting signal 11 crashes from nginx with 
docker-registry-proxy versions 0.6.2 and 0.6.4 (test performed pulling `ubuntu` through `docker-registry-proxy` without it being in the cache):
```
2022/10/19 03:54:57 [alert] 74#74: worker process 76 exited on signal 11
```
Leading to image pull errors in Docker and Kubernetes, e.g.:
```
docker: error pulling image configuration: download failed after attempts=6: EOF.
```

With the latest code in master, I get failures like instead of signal 11, but it sometimes seems to work, however:
```
2022/10/19 04:00:39 [crit] 83#83: *23 connect() to [2606:4700::6812:7c19]:443 failed (99: Address not available) while connecting to upstream, client: 127.0.0.1, server: proxy_caching_, request: "GET /v2/library/ubuntu/blobs/sha256:d63f752103bb93d846e17fa9996d3e708717c51b106382fe84d8527ee47a3547 HTTP/1.1", upstream: "https://[2606:4700::6812:7c19]:443/registry-v2/docker/registry/v2/blobs/sha256/d6/d63f752103bb93d846e17fa9996d3e708717c51b106382fe84d8527ee47a3547/data?verify=1666155039-2OQ%2BkxWXW53KIWSACLv3vpuPCD8%3D", host: "registry-1.docker.io"
```

If I set `DISABLE_IPV6=true` with this change, it works just fine, no errors like shown above.