### PR TITLE
Add support for Google Artifact Registry (GAR)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,7 @@ jobs:
           - { id: "manifest-cache", extraDockerOpts: "-e ENABLE_MANIFEST_CACHE=true", extraImageToPull: "", runner: "ubuntu-22.04" }
           - { id: "disable-ipv6", extraDockerOpts: "-e DISABLE_IPV6=true", extraImageToPull: "", runner: "ubuntu-22.04" }
           - { id: "manifest-noipv6-arm64-ghcr", extraDockerOpts: "-e ENABLE_MANIFEST_CACHE=true -e DISABLE_IPV6=true", extraImageToPull: "ghcr.io/rpardini/ansi-hastebin:0.0.8-node20", runner: "ubuntu-22.04-arm" }
+          - { id: "manifest-noipv6-arm64-gcr", extraDockerOpts: "-e ENABLE_MANIFEST_CACHE=true -e DISABLE_IPV6=true", extraImageToPull: "mirror.gcr.io/busybox:latest", runner: "ubuntu-22.04-arm" }
 
     runs-on: "${{ matrix.runner }}"
     name: "${{ matrix.id }} (${{ matrix.extraDockerOpts }})"

--- a/nginx.conf
+++ b/nginx.conf
@@ -18,6 +18,10 @@ http {
     # Include nginx timeout configs
     include       /etc/nginx/nginx.timeouts.config.conf;
 
+    # Support Google Artifact Registry big headers
+    proxy_buffer_size   128k;
+    proxy_buffers   4 256k;
+
     # Use a debug-oriented logging format.
     log_format debugging escape=json
       '{'
@@ -296,6 +300,10 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
             set $original_uri $uri;
             set $orig_loc $upstream_http_location;
 
+            # Special handling for Google Artifact Registry
+            if ($upstream_http_location !~* "^https?://") {
+                 set $orig_loc "https://${host}${upstream_http_location}";
+            }
             # during this process, nginx will preserve the headers intended for the original destination.
             # in most cases thats okay, but for some (eg: google storage), passing an Authorization
             # header can cause problems. Also, that would leak the credentials for the registry


### PR DESCRIPTION
This pull request addresses issue #159 and adds support for Google Artifact Registry (GAR).

I have added the proxy buffer tweaks that @vitaliihrynko1 suggested in the original issue, as well as my own tweak of the `$orig_loc` variable which resolves the issue of redirection from `/v2/` to `/artifacts-download/` in my testing. 

I'm certainly no nginx expert, so it's very possible that I did something completely wrong. Critique is welcome!