### PR TITLE
Fix an unclosed quoting issue in kind setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ for NODE in $(kind get nodes --name "$KIND_NAME"); do
       curl $SETUP_URL \
       | sed s/docker\.service/containerd\.service/g \
       | sed '/Environment/ s/$/ \"NO_PROXY=127.0.0.0\/8,10.0.0.0\/8,172.16.0.0\/12,192.168.0.0\/16\"/' \
-      | bash" & pids="$pids $!" # Configure every node in background
+      | bash" & pids="$pids $! " # Configure every node in background
 done
 wait $pids # Wait for all configurations to end
 ```


### PR DESCRIPTION
Per [this](https://github.com/rpardini/docker-registry-proxy/issues/168) issue I think there is a problem in these setup instructions because (at least for zsh) the shell doesn't like the combination of !" and this means that the double quote remains unclosed. 

There are probably more elegant ways to fix this problem but I just took the easy one here.