### PR TITLE
Increase proxy_ssl_verify_depth to handle intermediate certificates

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -281,7 +281,9 @@ if [[ "a${VERIFY_SSL}" == "atrue" ]]; then
     # We'll accept any cert signed by a CA trusted by Mozilla (ca-certificates-bundle in alpine)
     proxy_ssl_verify on;
     proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
-    proxy_ssl_verify_depth 2;
+    # docker.io has changed their certificate chain to include another intermediate certificate,
+    # original value of 2 is not enough, bump up depth to 3.
+    proxy_ssl_verify_depth 3;
 EOD
     echo "Upstream SSL certificate verification enabled."
 else


### PR DESCRIPTION
Receiving SSL error now since an intermediate certificate is added to docker.io

```
2026/06/15 19:12:14 [error] 75#75: *11 upstream SSL certificate verify error: (22:certificate chain too long) while SSL handshaking to upstream, client: 127.0.0.1, server: proxy_caching_, request: "GET /token?scope=repository%3Alibrary%2Fubuntu%3Apull&service=registry.docker.io HTTP/1.1", upstream: "https://104.18.43.178:443/token?scope=repository%3Alibrary%2Fubuntu%3Apull&service=registry.docker.io", host: "auth.docker.io"
2026/06/15 19:12:14 [warn] 75#75: *11 upstream server temporarily disabled while SSL handshaking to upstream, client: 127.0.0.1, server: proxy_caching_, request: "GET /token?scope=repository%3Alibrary%2Fubuntu%3Apull&service=registry.docker.io HTTP/1.1", upstream: "https://104.18.43.178:443/token?scope=repository%3Alibrary%2Fubuntu%3Apull&service=registry.docker.io", host: "auth.docker.io"
```
Increasing the proxy_ssl_verify_depth to 3, the problem is fixed.

```
{"access_time":"15/Jun/2026:19:21:50 +0000","upstream_cache_status":"HIT","method":"HEAD","uri":"/v2/library/ubuntu/manifests/24.04","request_type":"manifest-secondary","status":"200","bytes_sent":"0","upstream_response_time":"","host":"registry-1.docker.io","proxy_host":"registry-1.docker.io","upstream":""}
{"access_time":"15/Jun/2026:19:21:50 +0000","upstream_cache_status":"","method":"GET","uri":"/v2/library/ubuntu/referrers/sha256:01a14a568a5c77390e74eefc7a2106206f4605338cb7e86e8bf06a18452b5169","request_type":"unknown","status":"401","bytes_sent":"157","upstream_response_time":"0.328","host":"registry-1.docker.io","proxy_host":"registry-1.docker.io","upstream":"54.234.221.194:443"}
{"access_time":"15/Jun/2026:19:21:50 +0000","upstream_cache_status":"","method":"GET","uri":"/token","request_type":"unknown","status":"200","bytes_sent":"5421","upstream_response_time":"0.131","host":"auth.docker.io","proxy_host":"auth.docker.io","upstream":"104.18.43.178:443"}
{"access_time":"15/Jun/2026:19:21:51 +0000","upstream_cache_status":"","method":"GET","uri":"/v2/library/ubuntu/referrers/sha256:01a14a568a5c77390e74eefc7a2106206f4605338cb7e86e8bf06a18452b5169","request_type":"unknown","status":"200","bytes_sent":"89","upstream_response_time":"0.340","host":"registry-1.docker.io","proxy_host":"registry-1.docker.io","upstream":"3.238.169.28:443"}
```

Fixes #181 